### PR TITLE
Use clock_gettime() when available and get rid of deprecated gettimeofday()

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -137,6 +137,10 @@ if (have_func ("rb_thread_fd_select"))
   $CFLAGS  += " -DHAVE_RB_THREAD_FD_SELECT"
 end
 
+if (have_func ("clock_gettime"))
+  $CFLAGS += " -DHAVE_CLOCK_GETTIME"
+end
+
 $CXXFLAGS  = $CFLAGS
 
 create_makefile('ncursesw_bin')


### PR DESCRIPTION
gettimeofday () fails on latest ruby 2.0.0 on arch linux, clock_gettime () is supposed to be platform specific though (missing on Mac & BSDs).

Tested successfully on:
- Arch Linux (ruby 1.8.7, 1.9.3, 2.0.0-p195)
