### PR TITLE
fail on missing libs and add some more descriptive output

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -141,7 +141,7 @@ else
   raise "menu library not found."
 end
 
-puts "checking for various ruby and libc functions.."
+puts "checking for various ruby and standard functions.."
 if have_func("rb_thread_fd_select")
   $CFLAGS  += " -DHAVE_RB_THREAD_FD_SELECT"
 end


### PR DESCRIPTION
This could catch old ncurses versions (not really fixing anything specific), sup needs these libs anyway.

Tested on Arch Linux
