### PR TITLE
Use dir_config() to set search path for ncurses header

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -27,6 +27,9 @@ $CFLAGS  += " -g -Wformat -Werror=format-security"
 have_header("unistd.h")
 have_header("locale.h")
 
+# make sure we are using the correct header (necessary on mac)
+dir_config ('ncurses')
+
 if have_header("ncurses.h")
   curses_header = "ncurses.h"
 elsif have_header("ncurses/curses.h")
@@ -136,9 +139,6 @@ end
 if have_func("rb_thread_fd_select")
   $CFLAGS  += " -DHAVE_RB_THREAD_FD_SELECT"
 end
-
-# add NCURSES_OPAQUE for mac
-$CFLAGS += " -DNCURSES_OPAQUE=0"
 
 if have_func("clock_gettime")
   $CFLAGS += " -DHAVE_CLOCK_GETTIME"


### PR DESCRIPTION
[do not merge yet]

NCURSES_OPAQUE is not set on Mac OS X, dir_config seems to fix this
on the Macports version.

https://trac.macports.org/browser/trunk/dports/ruby/rb-ncurses-ruby/files/extconf.rb.diff

Untested, but a more correct way to fix https://github.com/sup-heliotrope/sup/issues/49.
