### PR TITLE
Support custom ncurses location

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -25,6 +25,8 @@ require "mkmf"
 
 $CFLAGS  += " -g -Wformat -Werror=format-security -Waddress"
 
+dir_config("ncurses")
+
 have_header("unistd.h")
 have_header("locale.h")
 


### PR DESCRIPTION
Adds option --with-ncurses-dir={path} to specify location for ncurses libs and include files.

Per https://github.com/sup-heliotrope/sup/issues/317#issuecomment-112227341