### PR TITLE
Detect when ncurses is ncursesw

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -49,6 +49,9 @@ end
 
 if have_library("ncursesw", "wmove")
   curses_lib = "ncursesw"
+elsif have_library("ncurses", "add_wch")
+  curses_lib = "ncurses"
+  curses_is_wide = true
 elsif have_library("pdcurses", "wmove")
   curses_lib = "pdcurses"
 else
@@ -147,7 +150,8 @@ end
 
 puts "checking for the form library..."
 if have_header("form.h") or have_header("ncursesw/form.h")
-  if not have_library("formw", "new_form")
+  if not have_library("formw", "new_form") ||
+      (curses_is_wide && have_library("form", "new_form"))
     raise "formw library not found"
   end
 else


### PR DESCRIPTION
Hey, sup team.  I really appreciate you guys grabbing the torch with ncursesw-ruby.

It's apparently becoming a thing for systems to only provide libncurses.so, but built with wide support.  macOS is now one of these, so ncursesw-ruby doesn't build.  This is distinct from the case where libncurses.so is built with wide character support, and libncursesw.so is a symlink to it.  They don't have a libncursesw.so at all.

This change to the build detects if 'libncurses' has wide functionality, and uses it if so.  It also assumes libform was built wide if libncurses was, which is also required to build on Darwin.

I've got an application that now has to depend on 'ncurses-ruby' on macOS and 'ncursesw' on other platforms to get wide character support.  'ncursesw' building on stock macOS again would let me get off of that fork and standardize on ncursesw.

Edit: package tested on Ubuntu 16.10.1 and macOS 10.12 preview.