### PR TITLE
Version bump for 1.4.10 release

### DIFF
--- a/ncursesw.gemspec
+++ b/ncursesw.gemspec
@@ -6,7 +6,7 @@ SUMMARY = 'This wrapper provides access to the functions, macros, global variabl
 
 spec = Gem::Specification.new do |s|
   s.name        = 'ncursesw'
-  s.version     = '1.4.9'
+  s.version     = '1.4.10'
   s.license     = 'LGPL-2.1'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Tobias Herzke', 'Sup developers']


### PR DESCRIPTION
Current gem build has been tested on the following configurations:

  * Ubuntu 14.04: ruby-1.8.7 libncursesw5-dev
  * Ubuntu 15.04: ruby1.9.1 libncursesw5-dev
  * Ubuntu 16.04.1: ruby2.3_2.3.1-2 libncursesw5-dev
  * Debian 7.11: ruby1.9.1-full libncursesw5-dev
  * Fedora 24: ruby-2.3.1p112 curses-devel.x86_64 6.0-6.20160709.fc24
  * FreeBSD 10.3-RELEASE ruby-2.2.5p319 ncurses-6.0_2
  * OS X 10.10 ruby-2.3.1 libncurses.5.4.dylib
  * OS X 10.11 ruby-2.3.1 libncurses.5.4.dylib
  * macOS 10.12-beta ruby-2.3-head libncurses.5.4.dylib

Where "tested" means successfully builds, installs, and the examples function.